### PR TITLE
feat: Implement Notebook Markdown Copier extension

### DIFF
--- a/answers.txt
+++ b/answers.txt
@@ -1,0 +1,8 @@
+1
+Notebook Markdown Copier
+notebook-markdown-copier
+A VS Code extension to copy selected Jupyter Notebook cells as a single markdown block and paste markdown back into a notebook as distinct cells.
+n
+n
+n
+npm

--- a/notebook-markdown-copier/.vscode/extensions.json
+++ b/notebook-markdown-copier/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "dbaeumer.vscode-eslint"
+  ]
+}

--- a/notebook-markdown-copier/.vscode/launch.json
+++ b/notebook-markdown-copier/.vscode/launch.json
@@ -1,0 +1,30 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}"
+      ],
+      "outFiles": [
+        "${workspaceFolder}/out/**/*.js"
+      ],
+      "preLaunchTask": "${defaultBuildTask}"
+    },
+    {
+      "name": "Extension Tests",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}",
+        "--extensionTestsPath=${workspaceFolder}/out/test/suite/index"
+      ],
+      "outFiles": [
+        "${workspaceFolder}/out/test/**/*.js"
+      ],
+      "preLaunchTask": "${defaultBuildTask}"
+    }
+  ]
+}

--- a/notebook-markdown-copier/.vscodeignore
+++ b/notebook-markdown-copier/.vscodeignore
@@ -1,0 +1,34 @@
+.vscode/**
+.vscode-test/**
+node_modules/
+out/test/**
+# Development configuration files
+.eslintrc.json
+**/.gitattributes
+**/.gitmodules
+**/.lintstagedrc.js
+**/.prettierignore
+**/.prettierrc.json
+**/jest.config.js
+**/jest.setup.js
+**/renovate.json
+**/wallaby.js
+.eslintignore
+# Build and test artifacts
+dist/
+coverage/
+.nyc_output/
+*.vsix
+*.tsbuildinfo
+*.log
+# OS-specific
+**/.DS_Store
+# Package manager specific
+.husky/
+.yarnrc.yml
+yarn.lock
+.npmrc
+.yarnclean
+.yarn/
+.pnp.cjs
+.pnp.loader.mjs

--- a/notebook-markdown-copier/CHANGELOG.md
+++ b/notebook-markdown-copier/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Change Log
+
+All notable changes to the "notebook-markdown-copier" extension will be documented in this file.
+
+## [0.0.1] - 2025-05-24
+- Initial release of Notebook Markdown Copier.
+- Feature: Copy selected notebook cells (Markdown and Code) as a single Markdown block.
+- Feature: Paste Markdown (containing text and code blocks) as new cells into a notebook.

--- a/notebook-markdown-copier/README.md
+++ b/notebook-markdown-copier/README.md
@@ -1,0 +1,53 @@
+# Notebook Markdown Copier for VS Code
+
+**A Visual Studio Code extension to easily copy selected Jupyter Notebook cells as a single markdown block and paste markdown back into a notebook as distinct cells.**
+
+This extension is designed to streamline the process of sharing notebook content with AI chatbots, documentation platforms, or any markdown-based system. It also helps in quickly bringing structured markdown back into your notebooks.
+
+## Features
+
+*   **Copy Selected Cells as Markdown**: Select one or more cells (Code or Markdown) in your Jupyter Notebook. The extension will convert them into a single, well-formatted markdown string and copy it to your clipboard.
+    *   Markdown cells are copied as is.
+    *   Code cells are wrapped in markdown code blocks, preserving their language identifier (e.g., ` ```python ... ``` `).
+*   **Paste Markdown as Cells**: Take a markdown string (formatted with text and code blocks as produced by the copy feature) from your clipboard and paste it into your active Jupyter Notebook. The extension will parse the markdown and create new cells accordingly:
+    *   Plain text becomes Markdown cells.
+    *   Markdown code blocks become Code cells with the appropriate language.
+
+## How to Use
+
+### 1. Copy Selected Cells as Markdown
+
+1.  Open a Jupyter Notebook (`.ipynb` file) in VS Code.
+2.  Select one or more cells you wish to copy.
+3.  Right-click on one of the selected cells to open the context menu.
+4.  Choose "**Notebook: Copy Selected Cells as Markdown**".
+    *   Alternatively, open the Command Palette (`Ctrl+Shift+P` or `Cmd+Shift+P`) and search for "Notebook: Copy Selected Cells as Markdown".
+5.  The formatted markdown will be copied to your clipboard. A notification will confirm the action.
+
+### 2. Paste Markdown as Cells
+
+1.  Ensure you have markdown text (formatted as described above, typically from this extension's copy command or a similar structure) on your clipboard.
+2.  Open a Jupyter Notebook (`.ipynb` file) in VS Code.
+3.  Click on a cell to select it. The new cells will be pasted *below* this cell. If no cell is selected, they will be pasted at the end of the notebook.
+4.  Right-click in the notebook area (e.g., on a cell or between cells) to open the context menu.
+5.  Choose "**Notebook: Paste Markdown as Cells**".
+    *   Alternatively, open the Command Palette (`Ctrl+Shift+P` or `Cmd+Shift+P`) and search for "Notebook: Paste Markdown as Cells".
+6.  The markdown from your clipboard will be parsed and inserted as new cells. A notification will confirm if successful, or show an error if the content is not parsable.
+
+## Requirements
+
+*   Visual Studio Code version `^1.76.0` or higher.
+*   A working Jupyter Notebook environment if you intend to run the notebooks (the extension itself operates on the `.ipynb` file structure).
+
+## Known Issues
+
+*   Currently, the parsing for "Paste Markdown as Cells" expects markdown primarily structured by this extension's copy command. Complex or unusually formatted markdown might not parse as expected.
+*   Error handling for extremely large clipboard content could be improved.
+
+## Release Notes
+
+See the [CHANGELOG.md](CHANGELOG.md) for details on each release.
+
+---
+
+**Enjoy using Notebook Markdown Copier!**

--- a/notebook-markdown-copier/package.json
+++ b/notebook-markdown-copier/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "notebook-markdown-copier",
+  "displayName": "Notebook Markdown Copier",
+  "description": "A VS Code extension to copy selected Jupyter Notebook cells as a single markdown block and paste markdown back into a notebook as distinct cells.",
+  "version": "0.0.1",
+  "engines": {
+    "vscode": "^1.76.0"
+  },
+  "categories": [
+    "Other"
+  ],
+  "activationEvents": [
+    "onNotebook:jupyter-notebook",
+    "onNotebook:python"
+  ],
+  "main": "./out/extension.js",
+  "contributes": {
+    "commands": [
+      {
+        "command": "notebook-markdown-copier.copyAsMarkdown",
+        "title": "Notebook: Copy Selected Cells as Markdown"
+      },
+      {
+        "command": "notebook-markdown-copier.pasteFromMarkdown",
+        "title": "Notebook: Paste Markdown as Cells"
+      }
+    ],
+    "menus": {
+      "notebook/cell/context": [
+        {
+          "command": "notebook-markdown-copier.copyAsMarkdown",
+          "when": "notebookEditorHasSelection",
+          "group": "2_copy@1"
+        },
+        {
+          "command": "notebook-markdown-copier.pasteFromMarkdown",
+          "group": "2_copy@2"
+        }
+      ]
+    }
+  },
+  "scripts": {
+    "vscode:prepublish": "npm run compile",
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./",
+    "pretest": "npm run compile && npm run lint",
+    "lint": "eslint src --ext ts",
+    "test": "vscode-test"
+  },
+  "devDependencies": {
+    "@types/vscode": "^1.76.0",
+    "@types/glob": "^8.1.0",
+    "@types/node": "18.x.x",
+    "eslint": "^8.57.0", 
+    "@typescript-eslint/parser": "^7.7.0",
+    "@typescript-eslint/eslint-plugin": "^7.7.0",
+    "glob": "^8.1.0",
+    "typescript": "^5.4.5",
+    "@types/mocha": "^10.0.6",
+    "@vscode/test-cli": "^0.0.9",
+    "@vscode/test-electron": "^2.3.9"
+  }
+}

--- a/notebook-markdown-copier/src/extension.ts
+++ b/notebook-markdown-copier/src/extension.ts
@@ -1,0 +1,19 @@
+import * as vscode from 'vscode';
+import { copyAsMarkdownHandler, pasteFromMarkdownHandler } from './notebookUtils'; // These will be created later
+
+export function activate(context: vscode.ExtensionContext) {
+    console.log('Congratulations, your extension "notebook-markdown-copier" is now active!');
+
+    let copyDisposable = vscode.commands.registerCommand('notebook-markdown-copier.copyAsMarkdown', () => {
+        copyAsMarkdownHandler();
+    });
+
+    let pasteDisposable = vscode.commands.registerCommand('notebook-markdown-copier.pasteFromMarkdown', () => {
+        pasteFromMarkdownHandler();
+    });
+
+    context.subscriptions.push(copyDisposable);
+    context.subscriptions.push(pasteDisposable);
+}
+
+export function deactivate() {}

--- a/notebook-markdown-copier/src/notebookUtils.ts
+++ b/notebook-markdown-copier/src/notebookUtils.ts
@@ -1,0 +1,148 @@
+import * as vscode from 'vscode';
+
+export async function copyAsMarkdownHandler() {
+    const editor = vscode.window.activeNotebookEditor;
+    if (!editor) {
+        vscode.window.showErrorMessage('No active Notebook Editor found.');
+        return;
+    }
+
+    const selectedRanges = editor.selections;
+    if (!selectedRanges || selectedRanges.length === 0 || (selectedRanges.length === 1 && selectedRanges[0].isEmpty && selectedRanges[0].start === selectedRanges[0].end) ) {
+        vscode.window.showInformationMessage('No cells selected to copy.');
+        return;
+    }
+
+    const allCells = editor.notebook.getCells();
+    const selectedCellIndices = new Set<number>();
+
+    selectedRanges.forEach(range => {
+        for (let i = range.start; i < range.end; i++) {
+            selectedCellIndices.add(i);
+        }
+    });
+
+    if (selectedCellIndices.size === 0) {
+        vscode.window.showInformationMessage('No cells effectively selected.');
+        return;
+    }
+
+    const selectedCells: vscode.NotebookCell[] = [];
+    selectedCellIndices.forEach(index => {
+        if (index < allCells.length) { // Ensure index is within bounds
+            selectedCells.push(allCells[index]);
+        }
+    });
+
+    // Sort selectedCells by their actual index in the notebook
+    selectedCells.sort((a, b) => a.index - b.index);
+
+    if (selectedCells.length === 0) { // Double check after filtering and sorting
+        vscode.window.showInformationMessage('No valid cells found in selection.');
+        return;
+    }
+
+    const markdownParts: string[] = [];
+
+    for (const cell of selectedCells) {
+        if (cell.kind === vscode.NotebookCellKind.Markup) {
+            markdownParts.push(cell.document.getText());
+        } else if (cell.kind === vscode.NotebookCellKind.Code) {
+            const languageId = cell.document.languageId || 'plaintext';
+            markdownParts.push(`\`\`\`${languageId}
+${cell.document.getText()}
+\`\`\``);
+        }
+    }
+
+    if (markdownParts.length > 0) {
+        const finalMarkdownString = markdownParts.join('\n\n');
+        try {
+            await vscode.env.clipboard.writeText(finalMarkdownString);
+            vscode.window.showInformationMessage('Selected cells copied as Markdown.');
+        } catch (error) {
+            console.error('Failed to copy to clipboard:', error);
+            vscode.window.showErrorMessage('Failed to copy selected cells to clipboard.');
+        }
+    } else {
+        vscode.window.showInformationMessage('No copyable content found in selected cells.');
+    }
+}
+
+export async function pasteFromMarkdownHandler() {
+    const editor = vscode.window.activeNotebookEditor;
+    if (!editor) {
+        vscode.window.showErrorMessage('No active Notebook Editor found.');
+        return;
+    }
+
+    let clipboardText;
+    try {
+        clipboardText = await vscode.env.clipboard.readText();
+    } catch (error) {
+        console.error('Failed to read from clipboard:', error);
+        vscode.window.showErrorMessage('Failed to read from clipboard.');
+        return;
+    }
+
+    if (!clipboardText.trim()) {
+        vscode.window.showInformationMessage('Clipboard is empty.');
+        return;
+    }
+
+    const newCellsArray: vscode.NotebookCellData[] = [];
+    const codeBlockRegex = /^```([a-zA-Z0-9_\-]+)?\n([\s\S]+?)^```$/gm;
+    let lastIndex = 0;
+    let match;
+
+    try {
+        while ((match = codeBlockRegex.exec(clipboardText)) !== null) {
+            // Add preceding markdown content if any
+            if (match.index > lastIndex) {
+                const markdownContent = clipboardText.substring(lastIndex, match.index).trim();
+                if (markdownContent) {
+                    newCellsArray.push(new vscode.NotebookCellData(vscode.NotebookCellKind.Markup, markdownContent, 'markdown'));
+                }
+            }
+
+            // Add code cell
+            const language = match[1] || 'plaintext'; // Default to 'plaintext' if language is not specified
+            const codeContent = match[2].trim(); // Trim to remove leading/trailing newlines within the block
+            if (codeContent) { // Ensure code content is not just whitespace
+                 newCellsArray.push(new vscode.NotebookCellData(vscode.NotebookCellKind.Code, codeContent, language));
+            }
+            lastIndex = codeBlockRegex.lastIndex;
+        }
+
+        // Add any remaining markdown content after the last code block
+        if (lastIndex < clipboardText.length) {
+            const markdownContent = clipboardText.substring(lastIndex).trim();
+            if (markdownContent) {
+                newCellsArray.push(new vscode.NotebookCellData(vscode.NotebookCellKind.Markup, markdownContent, 'markdown'));
+            }
+        }
+
+        if (newCellsArray.length === 0) {
+            vscode.window.showInformationMessage('Could not parse any cells from clipboard content.');
+            return;
+        }
+
+        let insertionIndex: number;
+        if (editor.selections && editor.selections.length > 0 && editor.selections[0].end !== undefined) {
+            insertionIndex = editor.selections[0].end;
+        } else {
+            insertionIndex = editor.notebook.cellCount;
+        }
+
+        const notebookEdit = vscode.NotebookEdit.insertCells(insertionIndex, newCellsArray);
+        const workspaceEdit = new vscode.WorkspaceEdit();
+        workspaceEdit.set(editor.notebook.uri, [notebookEdit]);
+
+        await vscode.workspace.applyEdit(workspaceEdit);
+        vscode.window.showInformationMessage('Cells pasted from Markdown.');
+
+    } catch (error) {
+        console.error('Failed to parse or paste Markdown:', error);
+        vscode.window.showErrorMessage('Failed to parse or paste cells from Markdown. Check console for details.');
+    }
+}

--- a/notebook-markdown-copier/tsconfig.json
+++ b/notebook-markdown-copier/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES2020",
+    "outDir": "./out",
+    "lib": [
+      "ES2020"
+    ],
+    "sourceMap": true,
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    ".vscode-test"
+  ]
+}


### PR DESCRIPTION
I've implemented the core functionality for the Notebook Markdown Copier VS Code extension.

Key changes:
- I set up the project structure for a TypeScript VS Code extension.
- I populated `package.json` with extension details, activation events, commands, context menus, and dependencies.
- I implemented `src/extension.ts` to register commands.
- I implemented `src/notebookUtils.ts` with:
  - `copyAsMarkdownHandler`: Copies selected notebook cells (Code and Markdown) to the clipboard as a formatted Markdown string.
  - `pasteFromMarkdownHandler`: Parses Markdown text (with code blocks) from the clipboard and pastes it as new cells into a notebook.
- I configured `tsconfig.json` for TypeScript compilation.
- I populated `.vscodeignore` to exclude unnecessary files from packaging.
- I created `CHANGELOG.md` with initial release notes.
- I updated `README.md` with comprehensive user documentation, including features and how-to-use instructions.

This provides a functional first version of the extension as per your specification. Further work could include adding unit tests for the parsing logic and more robust error handling for edge cases.